### PR TITLE
Add permissions so post comment step will work

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   scan-action:
     runs-on: ubuntu-latest
@@ -37,7 +40,8 @@ jobs:
           path: ${{ github.workspace }}/_accessibility-reports/index.html
 
       # Optional: post a comment on the pull request with the summary report
-      - uses: actions/github-script@v7
+      - name: Post comment
+        uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -40,7 +40,7 @@ jobs:
           path: ${{ github.workspace }}/_accessibility-reports/index.html
 
       # Optional: post a comment on the pull request with the summary report
-      - name: Post comment
+      - name: Post report as comment on pull request
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
           path: ${{ github.workspace }}/_accessibility-reports/index.html
 
       # Optional: post a comment on the pull request with the summary report
-      - name: Post comment
+      - name: Post report as comment on pull request
         uses: actions/github-script@v7
         if: github.event_name == 'pull_request'
         with:


### PR DESCRIPTION
I noticed recent dependanbot PRs failed at the post comment step. Trying `permissions` to see if it will prevent the step from failing.