### PR TITLE
Adopt TypeScript strict mode and nodenext module resolution

### DIFF
--- a/dist/action.js
+++ b/dist/action.js
@@ -1,5 +1,7 @@
 import "reflect-metadata";
-import * as inversify from "inversify";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const inversify = require("inversify");
 import { Scanner } from "./scan.js";
 import scanPkg from "accessibility-insights-scan";
 const { setupCliContainer } = scanPkg;
@@ -21,7 +23,7 @@ export async function action() {
         await scanner.scan();
     }
     catch (error) {
-        setFailed(error);
+        setFailed(error instanceof Error ? error : String(error));
         return;
     }
 }

--- a/dist/scan.js
+++ b/dist/scan.js
@@ -37,7 +37,7 @@ let Scanner = class Scanner {
     async invokeScan() {
         let scanArguments;
         try {
-            const baselineFile = getInput("baselineFile") || null;
+            const baselineFile = getInput("baselineFile") || undefined;
             const inputUrls = getInput("inputUrls")
                 ? getInput("inputUrls").split(",")
                 : [];
@@ -60,7 +60,7 @@ let Scanner = class Scanner {
             const combinedReportParameters = this.getCombinedReportParameters(combinedScanResult, scanStarted, scanEnded);
             this.reportGenerator.generateReport(combinedReportParameters);
             await this.baselineFileUpdater.updateBaseline(scanArguments, combinedScanResult.baselineEvaluation);
-            if (baselineFile !== null) {
+            if (baselineFile !== undefined) {
                 if (combinedScanResult.baselineEvaluation?.suggestedBaselineUpdate &&
                     inputUrls.length === 0) {
                     setFailed("The baseline file does not match scan results.");
@@ -84,7 +84,7 @@ let Scanner = class Scanner {
             return Promise.resolve(this.scanSucceeded);
         }
         catch (error) {
-            setFailed(error);
+            setFailed(error instanceof Error ? error : String(error));
         }
         finally {
             info(`Accessibility scanning of URL ${scanArguments?.url} completed`);
@@ -95,16 +95,20 @@ let Scanner = class Scanner {
         this.scanSucceeded = false;
     }
     getCombinedReportParameters(combinedScanResult, scanStarted, scanEnded) {
+        const { scanMetadata } = combinedScanResult;
+        if (!scanMetadata) {
+            throw new Error("Scan metadata is missing from the combined scan result.");
+        }
         const scanResultData = {
-            baseUrl: combinedScanResult.scanMetadata.baseUrl ?? "n/a",
-            basePageTitle: combinedScanResult.scanMetadata.basePageTitle,
+            baseUrl: scanMetadata.baseUrl ?? "n/a",
+            basePageTitle: scanMetadata.basePageTitle,
             scanEngineName: "accessibility-scan-action",
             axeCoreVersion: axe.version,
-            browserUserAgent: combinedScanResult.scanMetadata.userAgent,
+            browserUserAgent: scanMetadata.userAgent,
             urlCount: combinedScanResult.urlCount,
             scanStarted,
             scanEnded,
-            browserResolution: combinedScanResult.scanMetadata.browserResolution,
+            browserResolution: scanMetadata.browserResolution,
         };
         return this.combinedReportDataConverter.convertCrawlingResults(combinedScanResult.combinedAxeResults, scanResultData);
     }

--- a/dist/summary/builders.js
+++ b/dist/summary/builders.js
@@ -65,6 +65,9 @@ export const failedRuleListItem = (failureCount, ruleId, description) => {
     return listItem(`${`${failureCount} × ${ruleId}`}:  ${description}`);
 };
 export function fixedFailureDetails({ baselineEvaluation, }) {
+    if (!baselineEvaluation) {
+        return [];
+    }
     if (!hasFixedFailureResults(baselineEvaluation)) {
         return [];
     }
@@ -100,7 +103,7 @@ export const failureDetailsBaseline = (combinedReportResult, baselineInfo) => {
         : [`No failures were detected by automatic scanning.\n`];
 };
 export const getTotalFailureInstancesFromResults = ({ results, }) => {
-    return results.resultsByRule.failed.reduce((a, b) => a + b.failed.reduce((c, d) => c + d.urls.length, 0), 0);
+    return results.resultsByRule.failed.reduce((a, b) => a + b.failed.reduce((c, d) => c + (d.urls?.length ?? 0), 0), 0);
 };
 export const getFailureInstances = (combinedReportResult, baselineEvaluation) => {
     if (baselineEvaluation) {
@@ -125,13 +128,16 @@ export const getNewFailuresList = (combinedReportResult, { newViolationsByRule }
 };
 export const getFailedRulesListWithNoBaseline = ({ results, }) => {
     return results.resultsByRule.failed.map(({ failed }) => {
-        const failureCount = failed.reduce((a, b) => a + b.urls.length, 0);
+        const failureCount = failed.reduce((a, b) => a + (b.urls?.length ?? 0), 0);
         const { ruleId, description } = failed[0].rule;
         return [failedRuleListItemBaseline(failureCount, ruleId, description)].join("");
     });
 };
 export const getRuleDescription = ({ results }, ruleId) => {
     const matchingFailuresGroup = results.resultsByRule.failed.find((failuresGroup) => failuresGroup.failed[0].rule.ruleId === ruleId);
+    if (!matchingFailuresGroup) {
+        return "";
+    }
     return matchingFailuresGroup.failed[0].rule.description;
 };
 export const failedRuleListItemBaseline = (failureCount, ruleId, description) => {
@@ -147,8 +153,7 @@ export function downloadArtifactsWithLink(combinedReportResult, baselineEvaluati
     ];
 }
 export const baselineHasFailures = (baselineEvaluation) => {
-    return (baselineEvaluation?.totalBaselineViolations &&
-        baselineEvaluation?.totalBaselineViolations > 0);
+    return (baselineEvaluation?.totalBaselineViolations ?? 0) > 0;
 };
 export const hasFailures = (combinedReportResult, baselineEvaluation) => {
     if (baselineEvaluation !== undefined) {

--- a/dist/summary/sections.js
+++ b/dist/summary/sections.js
@@ -7,7 +7,7 @@ export function sectionHeading(failed, baselinedEnabled, combinedReportResult) {
 ${downloadArtifactsWithLink(combinedReportResult)}`;
 }
 export function sectionSummary(combinedReportResult, baselinedEnabled) {
-    const { results: { resultsByRule: { passed, notApplicable, failed }, urlResults: { passedUrls, unscannableUrls, failedUrls }, }, } = combinedReportResult;
+    const { results: { resultsByRule: { passed = [], notApplicable = [], failed }, urlResults: { passedUrls, unscannableUrls, failedUrls }, }, } = combinedReportResult;
     return `## Scan summary
 
 ${urlsListItem(passedUrls, unscannableUrls, failedUrls, baselinedEnabled)}
@@ -23,7 +23,7 @@ export function sectionFailureSummary({ results: { resultsByRule: { failed }, },
 ${failedRulesList.join("\n")}`;
 }
 export function sectionBaseline(baselinedEnabled, baselineInfo, combinedReportResult) {
-    if (!baselinedEnabled)
+    if (!baselinedEnabled || !baselineInfo)
         return "";
     const content = [
         ...fixedFailureDetails(baselineInfo),

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,8 +12,7 @@ const config: Config = {
     "<rootDir>/src/__tests__/action.test.ts",
   ],
   moduleNameMapper: {
-    "./builders.js": "<rootDir>/src/summary/builders.ts",
-    "./sections.js": "<rootDir>/src/summary/sections.ts",
+    "^(\\.{1,2}/.*)\\.js$": "$1",
   },
 };
 

--- a/src/__tests__/summary.test.ts
+++ b/src/__tests__/summary.test.ts
@@ -1,6 +1,6 @@
 import { jest, describe, test, expect, beforeEach, afterEach } from "@jest/globals";
-import jsn from "./fixtures/jsnmrs";
-import wash from "./fixtures/wash";
+import jsn from "./fixtures/jsnmrs.js";
+import wash from "./fixtures/wash.js";
 
 const mockGetInput = jest.fn<(name: string) => string>();
 const mockGetBooleanInput = jest.fn<() => boolean>().mockReturnValue(false);
@@ -10,7 +10,7 @@ jest.unstable_mockModule("@actions/core", () => ({
   getBooleanInput: mockGetBooleanInput,
 }));
 
-const { markdownSummary } = await import("../summary/index");
+const { markdownSummary } = await import("../summary/index.js");
 
 const defaultOptions: {
   [key: string]: string;
@@ -21,7 +21,7 @@ const defaultOptions: {
 
 describe("markdownSummary", () => {
   beforeEach(() => {
-    mockGetInput.mockImplementation((v) => defaultOptions[v] || undefined);
+    mockGetInput.mockImplementation((v) => defaultOptions[v] || "");
   });
 
   afterEach(() => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,9 @@
 import "reflect-metadata";
 
-import * as inversify from "inversify";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+import type * as Inversify from "inversify" with { "resolution-mode": "require" };
+const inversify = require("inversify") as typeof Inversify;
 import { Scanner } from "./scan.js";
 import scanPkg from "accessibility-insights-scan";
 const { setupCliContainer } = scanPkg;
@@ -26,7 +29,7 @@ export async function action() {
     const scanner = container.get(Scanner);
     await scanner.scan();
   } catch (error) {
-    setFailed(error);
+    setFailed(error instanceof Error ? error : String(error));
     return;
   }
 }

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,5 +1,5 @@
 import { getInput } from "@actions/core";
-import {
+import type {
   ReporterFactory,
   CombinedReportParameters,
 } from "accessibility-insights-report";

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -43,9 +43,9 @@ export class Scanner {
   ) {}
 
   private async invokeScan(): Promise<boolean> {
-    let scanArguments: ScanArguments;
+    let scanArguments: ScanArguments | undefined;
     try {
-      const baselineFile = getInput("baselineFile") || null;
+      const baselineFile = getInput("baselineFile") || undefined;
       const inputUrls = getInput("inputUrls")
         ? getInput("inputUrls").split(",")
         : [];
@@ -88,7 +88,7 @@ export class Scanner {
         combinedScanResult.baselineEvaluation
       );
 
-      if (baselineFile !== null) {
+      if (baselineFile !== undefined) {
         if (
           combinedScanResult.baselineEvaluation?.suggestedBaselineUpdate &&
           inputUrls.length === 0
@@ -122,7 +122,7 @@ export class Scanner {
 
       return Promise.resolve(this.scanSucceeded);
     } catch (error) {
-      setFailed(error);
+      setFailed(error instanceof Error ? error : String(error));
     } finally {
       info(`Accessibility scanning of URL ${scanArguments?.url} completed`);
     }
@@ -139,16 +139,21 @@ export class Scanner {
     scanStarted: Date,
     scanEnded: Date
   ): CombinedReportParameters {
+    const { scanMetadata } = combinedScanResult;
+    if (!scanMetadata) {
+      throw new Error("Scan metadata is missing from the combined scan result.");
+    }
+
     const scanResultData = {
-      baseUrl: combinedScanResult.scanMetadata.baseUrl ?? "n/a",
-      basePageTitle: combinedScanResult.scanMetadata.basePageTitle,
+      baseUrl: scanMetadata.baseUrl ?? "n/a",
+      basePageTitle: scanMetadata.basePageTitle,
       scanEngineName: "accessibility-scan-action",
       axeCoreVersion: axe.version,
-      browserUserAgent: combinedScanResult.scanMetadata.userAgent,
+      browserUserAgent: scanMetadata.userAgent,
       urlCount: combinedScanResult.urlCount,
       scanStarted,
       scanEnded,
-      browserResolution: combinedScanResult.scanMetadata.browserResolution,
+      browserResolution: scanMetadata.browserResolution,
     };
 
     return this.combinedReportDataConverter.convertCrawlingResults(

--- a/src/summary/builders.ts
+++ b/src/summary/builders.ts
@@ -62,7 +62,7 @@ export function baselineDetails(baselineInfo: BaselineInfo): string[] {
 }
 
 export function shouldUpdateBaselineFile(
-  baselineEvaluation: BaselineEvaluation
+  baselineEvaluation?: BaselineEvaluation
 ): boolean {
   return baselineEvaluation && baselineEvaluation.suggestedBaselineUpdate
     ? true
@@ -122,6 +122,10 @@ export const failedRuleListItem = (
 export function fixedFailureDetails({
   baselineEvaluation,
 }: BaselineInfo): string[] {
+  if (!baselineEvaluation) {
+    return [];
+  }
+
   if (!hasFixedFailureResults(baselineEvaluation)) {
     return [];
   }
@@ -180,14 +184,14 @@ export const getTotalFailureInstancesFromResults = ({
   results,
 }: CombinedReportParameters): number => {
   return results.resultsByRule.failed.reduce(
-    (a, b) => a + b.failed.reduce((c, d) => c + d.urls.length, 0),
+    (a, b) => a + b.failed.reduce((c, d) => c + (d.urls?.length ?? 0), 0),
     0
   );
 };
 
 export const getFailureInstances = (
   combinedReportResult: CombinedReportParameters,
-  baselineEvaluation: BaselineEvaluation
+  baselineEvaluation?: BaselineEvaluation
 ): number => {
   if (baselineEvaluation) {
     return baselineEvaluation.totalNewViolations;
@@ -198,7 +202,7 @@ export const getFailureInstances = (
 
 export const getFailedRulesList = (
   combinedReportResult: CombinedReportParameters,
-  baselineEvaluation: BaselineEvaluation
+  baselineEvaluation?: BaselineEvaluation
 ): string[] => {
   if (baselineEvaluation) {
     return getNewFailuresList(combinedReportResult, baselineEvaluation);
@@ -229,7 +233,7 @@ export const getFailedRulesListWithNoBaseline = ({
   results,
 }: CombinedReportParameters): string[] => {
   return results.resultsByRule.failed.map(({ failed }) => {
-    const failureCount = failed.reduce((a, b) => a + b.urls.length, 0);
+    const failureCount = failed.reduce((a, b) => a + (b.urls?.length ?? 0), 0);
     const { ruleId, description } = failed[0].rule;
     return [failedRuleListItemBaseline(failureCount, ruleId, description)].join(
       ""
@@ -244,6 +248,10 @@ export const getRuleDescription = (
   const matchingFailuresGroup = results.resultsByRule.failed.find(
     (failuresGroup) => failuresGroup.failed[0].rule.ruleId === ruleId
   );
+
+  if (!matchingFailuresGroup) {
+    return "";
+  }
 
   return matchingFailuresGroup.failed[0].rule.description;
 };
@@ -275,17 +283,14 @@ export function downloadArtifactsWithLink(
 }
 
 export const baselineHasFailures = (
-  baselineEvaluation: BaselineEvaluation
+  baselineEvaluation?: BaselineEvaluation
 ): boolean => {
-  return (
-    baselineEvaluation?.totalBaselineViolations &&
-    baselineEvaluation?.totalBaselineViolations > 0
-  );
+  return (baselineEvaluation?.totalBaselineViolations ?? 0) > 0;
 };
 
 export const hasFailures = (
   combinedReportResult: CombinedReportParameters,
-  baselineEvaluation: BaselineEvaluation
+  baselineEvaluation?: BaselineEvaluation
 ): boolean => {
   if (baselineEvaluation !== undefined) {
     return baselineEvaluation.totalNewViolations > 0;

--- a/src/summary/sections.ts
+++ b/src/summary/sections.ts
@@ -35,7 +35,7 @@ export function sectionSummary(
 ) {
   const {
     results: {
-      resultsByRule: { passed, notApplicable, failed },
+      resultsByRule: { passed = [], notApplicable = [], failed },
       urlResults: { passedUrls, unscannableUrls, failedUrls },
     },
   } = combinedReportResult;
@@ -75,10 +75,10 @@ ${failedRulesList.join("\n")}`;
 
 export function sectionBaseline(
   baselinedEnabled: boolean,
-  baselineInfo: BaselineInfo,
+  baselineInfo: BaselineInfo | undefined,
   combinedReportResult: CombinedReportParameters
 ) {
-  if (!baselinedEnabled) return "";
+  if (!baselinedEnabled || !baselineInfo) return "";
   const content = [
     ...fixedFailureDetails(baselineInfo),
     ...failureDetailsBaseline(combinedReportResult, baselineInfo),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "rootDir": "src",
-    "strict": false,
+    "strict": true,
+    "isolatedModules": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Closes #137.

PR #136 added three `tsconfig.json` suppressions (`strict: false`, `ignoreDeprecations: "6.0"`, classic `moduleResolution: "node"`) to keep that PR scoped to the dependency bump. This change removes all three and fixes the type-safety gaps they hid.

## Approach

Targets **`nodenext`** rather than `bundler`: the action is `"type": "module"`, compiled by plain `tsc`, and Node 24 runs `dist/index.js` directly — so `nodenext` models the real runtime, and the source already uses `.js` import extensions everywhere except the test. `bundler` would be lower-effort but semantically a fiction (there is no bundler).

## Changes

- **tsconfig**: `module`/`moduleResolution` → `nodenext`; `strict: true`; `isolatedModules: true`; removed `ignoreDeprecations` and classic resolution.
- **26 strict errors** fixed with guards/narrowing — no `!` or `as any` introduced:
  - `catch (unknown)` narrowed before `setFailed` (`action.ts`, `scan.ts`).
  - `scanArguments` definite-assignment fix; `scanMetadata` guard.
  - Baseline summary helpers given honest optional parameters (their bodies already handled `undefined`); `urls`/`matchingFailuresGroup` guards; boolean/undefined cleanups.
- **inversify dual-package hazard**: under `nodenext` our `import * as inversify` flips to inversify's ESM build while `accessibility-insights-scan` (CJS) typed `setupCliContainer` against the CJS `Container`. Loading inversify via `createRequire` forces the shared CJS instance. This is a runtime-correctness fix, not a cast — verified by resolving `container.get(Scanner)` at runtime.
- **Tests/jest**: explicit `.js` extensions on test imports; replaced the two per-file `moduleNameMapper` entries with the standard relative-`.js` mapper.
- **report.ts**: type-only import converted to `import type` (required by `isolatedModules` + `emitDecoratorMetadata`).
- Rebuilt `dist/`.

## Verification

- `npx tsc --noEmit` — zero errors.
- `npm run build` — succeeds, `dist/` stays flat.
- `npm test` — 6/6 pass, pristine output.
- Runtime smoke test resolved `container.get(Scanner)` cleanly (the inversify path the unit test doesn't cover).

## Acceptance criteria

- [x] `tsconfig.json` has no `strict: false`, `ignoreDeprecations`, or deprecated `moduleResolution`.
- [x] `npx tsc --noEmit` passes with zero errors.
- [x] `npm run build` and `npm test` pass.
- [x] No new `!` / `as any` escape hatches.