### PR TITLE
Fix detached HEAD failure in commit-and-push workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref_name }}
       - uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          ref: ${{ github.ref_name }}
       - name: Documentation action
         id: documentation
         uses: katydecorah/documentation-action@v1.5.0


### PR DESCRIPTION
## Problem

The "Write documentation" workflow fails at the `Commit files` step with:

```
You are not currently on a branch.
Please specify which branch you want to merge with.
Error: Process completed with exit code 1.
```

`actions/checkout` checks out a *detached HEAD* at the triggering commit SHA (its default behavior). The bare `git pull` that follows then has no current branch to merge into, so it aborts and fails the step.

`build.yml` contained the identical `git pull`-after-checkout pattern and the same latent bug.

## Fix

Pass the triggering branch to checkout via `ref: ${{ github.ref_name }}`. The repo then lands on a real branch with upstream tracking, so the subsequent `git pull` / `git push` work normally.

Applied to both `documentation.yml` and `build.yml`.

## Verification

- YAML indentation under the new `with:` block is valid.
- documentation.yml: pushing a change to a trigger path (e.g. `README.md`, `action.yml`) should run the workflow and commit/push docs without the detached-HEAD error.
- build.yml: triggering via `workflow_dispatch` should complete the `Commit files` step (commit + push if `dist` changed, otherwise log "No changes to commit").