### PR TITLE
Override transitive protobufjs and js-yaml to patched versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,6 +2017,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+      "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3174,24 +3186,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-logs-otlp-http/node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+      "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3560,24 +3560,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+      "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -3968,24 +3956,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+      "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5385,12 +5361,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -7100,24 +7070,12 @@
       }
     },
     "node_modules/applicationinsights/node_modules/protobufjs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
-      "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
-      "hasInstallScript": true,
+      "version": "8.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.5.tgz",
+      "integrity": "sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -7131,14 +7089,10 @@
       "license": "MIT"
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -8004,34 +7958,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-require": {
@@ -11055,14 +10981,22 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-      "dev": true,
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
@@ -12958,13 +12892,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,11 @@
     "accessibility-insights-report": "^7.7.0",
     "accessibility-insights-scan": "^3.3.0",
     "inversify": "^6.2.1"
+  },
+  "overrides": {
+    "applicationinsights": {
+      "protobufjs": "^8.6.0"
+    },
+    "js-yaml": "^4.2.0"
   }
 }


### PR DESCRIPTION
## Background

The 13 open Dependabot alerts are **all transitive** dependencies of `accessibility-insights-scan`. Both top-level packages (`accessibility-insights-scan@3.3.0`, `accessibility-insights-report@7.7.0`) are already on their latest published release, so there is no upstream version to bump to. `npm audit fix --force` is not an option — it wants to downgrade `accessibility-insights-scan` to 0.5.1, a catastrophic breaking change.

## What this PR does

Adds `overrides` to force the two **non-breaking** patches:

| Package | Override | Clears |
|---|---|---|
| `protobufjs` | `^8.6.0` (scoped under `applicationinsights`) | 8 advisories, incl. both **high**-severity code-injection / DoS issues (moves the OpenTelemetry exporters off 8.0.1) |
| `js-yaml` | `^4.2.0` | Quadratic-complexity DoS advisory in the **test-only** `babel-plugin-istanbul` path |

`js-yaml` 4 is safe here: the only v3 consumer, `@istanbuljs/load-nyc-config`, calls `.load()` (not the removed `.safeLoad()`).

## Deliberately left as-is

`uuid` and `@opentelemetry/core` would each need a **breaking major** bump (uuid v8→v11, otel-core v1→v2) on Azure ApplicationInsights telemetry deps that are not in this action's execution path (the scan uses axe-core + Puppeteer, not the telemetry exporters). Forcing those risks destabilizing the scanner for no real-world security gain. Net effect: 13 Dependabot alerts → ~2.

## Verification

- `npm run build` (tsc) — passes
- `eslint` + Jest suite (6/6) — passes
- **Real Chrome scan** against a local page — crawler launched, axe-core ran, reports generated, no protobufjs/js-yaml/telemetry runtime failures
- `npm audit`: 51 → 32 findings, **2 high → 0 high**